### PR TITLE
DASU-1 Implement docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.idea
+.gradle
+node_modules
+build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.idea
+.gradle
+node_modules
+build

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:8
+
+ARG version
+
+RUN echo ${version}
+
+ADD build/libs/dasu-api-*.jar dasu-api.jar
+EXPOSE 8090
+ENTRYPOINT ["java", "-jar", "dasu-api.jar"]

--- a/api/settings.gradle
+++ b/api/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'api'
+rootProject.name = 'dasu-api'

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -1,1 +1,14 @@
+spring.datasource.url = jdbc:mysql://dasu-db:3306/api_db?useSSL=false&allowPublicKeyRetrieval=true
+spring.datasource.username = root
+spring.datasource.password = password
 
+# Show or not log for each sql query
+spring.jpa.show-sql = true
+
+# Hibernate ddl auto (create, create-drop, update)
+spring.jpa.hibernate.ddl-auto = update
+
+# The SQL dialect makes Hibernate generate better SQL for the chosen database
+spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQL5Dialect
+
+server.port=8090

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3'
+
+services:
+  frontend:
+    build: ./frontend
+    container_name: dasu-frontend
+    command: ng serve --host 0.0.0.0 --port 4200
+    restart: unless-stopped
+    ports:
+      - 4200:4200
+    networks:
+      - dasu-network
+
+  api:
+    build: ./api
+    container_name: dasu-api
+    restart: unless-stopped
+    networks:
+      - dasu-network
+    depends_on:
+      - api_db
+
+  api_db:
+    image: library/mysql:8.0.22
+    container_name: dasu-db
+    restart: unless-stopped
+    environment:
+      - MYSQL_ROOT_PASSWORD=password
+      - MYSQL_DATABASE=api_db
+      - MYSQL_USER=root
+      - MYSQL_PASSWORD=password
+    ports:
+      - 3306:3306
+    volumes:
+      - mysql_db:/var/lib/mysql
+    networks:
+      - dasu-network
+
+volumes:
+  mysql_db:
+
+networks:
+  dasu-network:
+    driver: bridge

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:13.12.0-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+RUN npm install -g @angular/cli
+
+COPY . .
+EXPOSE 4200
+CMD ["npm", "start"]


### PR DESCRIPTION
Implement docker-compose
- add .dockerignore;
- include .idea , .gradle , build, node_modules into main .gitignore;
- implement application.properties for mysql database connection in docker-compose containers;
- add docker-compose.yml with frontend , api and mysql database container run configurations;
- add Dockerfiles for frontend and api services;
- rename api service rootProject.name to "dasu-api" in service settings.gradle;
